### PR TITLE
fix: fix locale behaviour when using scheduling vis

### DIFF
--- a/src/amplience-api/index.ts
+++ b/src/amplience-api/index.ts
@@ -12,8 +12,8 @@ export type IdOrKey = {id: string} | {key: string}
  * @returns The fallback locale.
  */
 const addFallback = (locale: string | undefined): string => {
-    if (locale == null) {
-        return 'en-US,*'
+    if (!locale) {
+        return '*'
     } else if (locale.indexOf(',') === -1) {
         return locale + ',*'
     }


### PR DESCRIPTION
Fixes the vis being blank when using visualization from scheduling (which provides locale as the empty string)